### PR TITLE
Make tasks idempotent

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,20 +1,16 @@
 ---
-- name: Create lib dir
-  file: path={{sbt_lib_path}} state=directory
+- name: Create /opt/src
+  file: path=/opt/src state=directory recurse=yes
 
-- name: Clean existing version {{sbt_version}} if it exists
-  file: path={{sbt_lib_path_target}} state=absent
+- name: Create lib dir
+  file: path={{sbt_lib_path_target}} state=directory recurse=yes
 
 - name: Download sbt v{{sbt_version}}
   get_url: url={{sbt_download_url}} 
-    dest=/tmp/{{sbt_archive_file}}
-    force=no
+    dest=/opt/src/{{sbt_archive_file}}
 
 - name: Unpack sbt
-  command: tar -xvf {{sbt_archive_file}} chdir=/tmp/
-
-- name: Move (by force) Sbt to lib
-  command: mv /tmp/sbt {{sbt_lib_path_target}} chdir=/tmp/
+  unarchive: src=/opt/src/{{sbt_archive_file}} dest={{sbt_lib_path_target}} copy=no
 
 - name: Link sbt
-  command: sudo ln -sf {{sbt_lib_path_target}}/bin/sbt {{sbt_link_target}}
+  file: state=link src={{sbt_lib_path_target}}/sbt/bin/sbt dest={{sbt_link_target}}


### PR DESCRIPTION
Hi, thanks for sharing this role.

This change avoids actions being performed and changes reported on every single run where this role is invoked, by altering the archive juggling approach a little bit and using more native Ansible modules instead of `command` tasks.

I'm not sure that I'm clear on the motivations of AnsibleShipyard, but I presume that if your goals are to build Docker images, you haven't generally cared much about idempotent tasks in your roles. If that's the case and you aren't interested in these changes, fine, let me know and I'll maintain my own fork of this. Please know, though, that idempotence is a best practice that configuration management users are going to expect, so if you share these roles on Galaxy (which you are), then a lack of it may attract comments or negative reviews.
